### PR TITLE
Pin fsspec gcsfs s3fs to 2021.11.0 in 0.6.1 image

### DIFF
--- a/images/pangeonotebook-2021.07.17_prefect-0.14.22_pangeoforgerecipes-0.6.1/requirements.txt
+++ b/images/pangeonotebook-2021.07.17_prefect-0.14.22_pangeoforgerecipes-0.6.1/requirements.txt
@@ -1,3 +1,6 @@
 pangeo-forge-recipes==0.6.1
 prefect[aws, azure, google, kubernetes]==0.14.22
 dask-cloudprovider[aws]==2021.3.1
+fsspec==2021.11.0
+gcsfs==2021.11.0
+s3fs==2021.11.0


### PR DESCRIPTION
## What I am changing

The `0.6.1` image did not declare explicit versions for fsspec, gcsfs, and s3fs. As a result, it ended up with incompatible versions of `fsspec` and `gcsfs`, resulting in failed GCS writes discovered via https://github.com/pangeo-forge/pangeo-forge-gcs-bakery/issues/19.

As noted in https://github.com/pangeo-forge/pangeo-forge-recipes/pull/247, pangeo-forge-recipes `0.6.1` does not work with fsspec  `> 2021.11.0`. To get a compatible complement of fsspec + gcsfs + s3fs, I have therefore pinned all three of these packages to `2021.11.0`.


## How I did it

Declared explicit versions for these packages in this image's requirements.txt.

## How you can test it

This was blocking https://github.com/pangeo-forge/pangeo-forge-gcs-bakery/issues/19, and the original image was non-functional for interface with GCS, so I've already [pushed this update to Docker Hub](https://hub.docker.com/layers/pangeo/pangeo-forge-bakery-images/pangeonotebook-2021.07.17_prefect-0.14.22_pangeoforgerecipes-0.6.1/images/sha256-2af1232cdc25fdf28bfe3baff8bb352057e80f22ade17b237754a58eda84e314?context=explore). Once we have more services relying on these images, it will probably be best to define some approval/testing process before updating them, but in this case, I just went for it. Hopefully this did not impact any one else's work.
