### PR TITLE
Add binder/Dockerfile pointing to latest image

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,0 +1,1 @@
+FROM pangeo/pangeo-forge-bakery-images:pangeonotebook-2021.07.17_prefect-0.14.22_pangeoforgerecipes-0.6.1


### PR DESCRIPTION
Looks like we are going to refactor this repo considerably, so we don't need to merge this PR.

I just needed somewhere to put a Dockerfile pointing to the latest image, to use as a Binder environment for the pangeo-forge-recipes tutorial notebooks.
