### PR TITLE
Add 0.8.2 image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build-image
 build-image:
-	docker build -t pangeo/pangeo-forge-bakery-images:$(image) -f ./images/$(image)/Dockerfile ./images/$(image)
+	docker build -t pangeo/pangeo-forge-bakery-images:$(image) -f ./images/$(image)/Dockerfile ./images/$(image) --platform linux/amd64
 
 .PHONY: push-image
 push-image:

--- a/images/pangeonotebook-2021.12.02_prefect-0.14.22_pangeoforgerecipes-0.8.2/Dockerfile
+++ b/images/pangeonotebook-2021.12.02_prefect-0.14.22_pangeoforgerecipes-0.8.2/Dockerfile
@@ -1,0 +1,5 @@
+FROM pangeo/pangeo-notebook:2021.12.02
+
+RUN mamba install -n notebook -c conda-forge -y pangeo-forge-recipes==0.8.2
+
+RUN mamba install -n notebook -c conda-forge -y "prefect[aws, google, kubernetes]==0.14.22"


### PR DESCRIPTION
## What I am changing

This PR adds an image for pangeo-forge-recipes `0.8.2`. It uses a Pangeo-notebook base image to match https://github.com/pangeo-forge/sandbox/pull/6.

## How I did it

Added Dockerfile for this image.

I also added the `--platform` option to the Makefile to prevent possible incompatibilities for images built locally by Apple M1 machines.

## How you can test it

This image is available on Docker Hub.