### PR TITLE
Add 0.8.3 image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build-image
 build-image:
-	docker build -t pangeo/pangeo-forge-bakery-images:$(image) -f ./images/$(image)/Dockerfile ./images/$(image)
+	docker build -t pangeo/pangeo-forge-bakery-images:$(image) -f ./images/$(image)/Dockerfile ./images/$(image) --platform linux/amd64
 
 .PHONY: push-image
 push-image:

--- a/images/pangeonotebook-2021.12.02_prefect-0.14.22_pangeoforgerecipes-0.8.2/Dockerfile
+++ b/images/pangeonotebook-2021.12.02_prefect-0.14.22_pangeoforgerecipes-0.8.2/Dockerfile
@@ -1,0 +1,5 @@
+FROM pangeo/pangeo-notebook:2021.12.02
+
+RUN mamba install -n notebook -c conda-forge -y pangeo-forge-recipes==0.8.2
+
+RUN mamba install -n notebook -c conda-forge -y "prefect[aws, google, kubernetes]==0.14.22"

--- a/images/pangeonotebook-2021.12.02_prefect-0.14.22_pangeoforgerecipes-0.8.3/Dockerfile
+++ b/images/pangeonotebook-2021.12.02_prefect-0.14.22_pangeoforgerecipes-0.8.3/Dockerfile
@@ -1,5 +1,5 @@
 FROM pangeo/pangeo-notebook:2021.12.02
 
-RUN mamba install -n notebook -c conda-forge -y pangeo-forge-recipes==0.8.3
+RUN mamba run -n notebook pip install pangeo-forge-recipes==0.8.3
 
 RUN mamba install -n notebook -c conda-forge -y "prefect[aws, google, kubernetes]==0.14.22"

--- a/images/pangeonotebook-2021.12.02_prefect-0.14.22_pangeoforgerecipes-0.8.3/Dockerfile
+++ b/images/pangeonotebook-2021.12.02_prefect-0.14.22_pangeoforgerecipes-0.8.3/Dockerfile
@@ -1,0 +1,5 @@
+FROM pangeo/pangeo-notebook:2021.12.02
+
+RUN mamba install -n notebook -c conda-forge -y pangeo-forge-recipes==0.8.3
+
+RUN mamba install -n notebook -c conda-forge -y "prefect[aws, google, kubernetes]==0.14.22"


### PR DESCRIPTION
## What I am changing

Adds an image for `pangeo-forge-recipes==0.8.3`

## How I did it

Copied the example of #29

## How you can test it

This image will be available shortly on Docker Hub

_Note_: This was motivated by https://github.com/pangeo-forge/noaa-coastwatch-geopolar-sst-feedstock/issues/2#issuecomment-1102950710
